### PR TITLE
Fix typos - move_by_paragraph instead of move_paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ sublime-MoveByParagraph
 
 A Sublime Text 2 plugin extension to the move command
 
-A new command is added, `"move_paragraph"`.  Two `"args"` are accepted:
+A new command is added, `"move_by_paragraph"`.  Two `"args"` are accepted:
 
 - `"forward"` (bool): True if this moves down the page
 - `"extend"` (bool): True if this should create a selection
@@ -14,15 +14,15 @@ Moving by Paragraph
 
 Example (add this to your keymap):
 
-    {"keys": ["ctrl+up"], "command": "move_paragraph", "args": {"forward": false}},
-    {"keys": ["ctrl+down"], "command": "move_paragraph", "args": {"forward": true}},
+    {"keys": ["ctrl+up"], "command": "move_by_paragraph", "args": {"forward": false}},
+    {"keys": ["ctrl+down"], "command": "move_by_paragraph", "args": {"forward": true}},
 
 ![Paragraph Movement](http://i.imgur.com/E4VlmZO.gif)
 
 Example with selection (add this to your keymap):
 
-     {"keys": ["ctrl+shift+up"], "command": "move_paragraph", "args": {"forward": false, "extend": true}},
-     {"keys": ["ctrl+shift+down"], "command": "move_paragraph", "args": {"forward": true, "extend": true}},
+     {"keys": ["ctrl+shift+up"], "command": "move_by_paragraph", "args": {"forward": false, "extend": true}},
+     {"keys": ["ctrl+shift+down"], "command": "move_by_paragraph", "args": {"forward": true, "extend": true}},
 
 ![Paragraph Selection](http://i.imgur.com/rXK3bcS.gif)
 


### PR DESCRIPTION
Fantastic plugin, fantastic readme. Mass thanks for the work. I suggest this pull request as I am sure your plugin will gather popularity and there will be people who will be confused by this minor mistake.
