### PR TITLE
Go to end/ignore whitespacey lines

### DIFF
--- a/MoveByParagraph.sublime-settings
+++ b/MoveByParagraph.sublime-settings
@@ -1,0 +1,3 @@
+{
+  "ignore_whitespace": false
+}

--- a/README.md
+++ b/README.md
@@ -3,10 +3,17 @@ sublime-MoveByParagraph
 
 A Sublime Text 2 plugin extension to the move command
 
-A new command is added, `"move_by_paragraph"`.  Two `"args"` are accepted:
+A new command is added, `"move_by_paragraph"`.  Three `"args"` are accepted:
 
 - `"forward"` (bool): True if this moves down the page
 - `"extend"` (bool): True if this should create a selection
+- `"to_next"` (bool): True if the cursor should stay in this paragraph if possible.
+    Default is true when moving forward, false when backward.
+
+There is also one setting:
+
+- `"move_by_paragraph_ignores_whitespace"` (bool): Default false.
+    Set to true to treat lines containing only spaces and tabs as empty.
 
 
 Moving by Paragraph
@@ -22,7 +29,7 @@ Example (add this to your keymap):
 Example with selection (add this to your keymap):
 
      {"keys": ["ctrl+shift+up"], "command": "move_by_paragraph", "args": {"forward": false, "extend": true}},
-     {"keys": ["ctrl+shift+down"], "command": "move_by_paragraph", "args": {"forward": true, "extend": true}},
+     {"keys": ["ctrl+shift+down"], "command": "move_by_paragraph", "args": {"forward": true, "extend": true, "to_next": false}},
 
 ![Paragraph Selection](http://i.imgur.com/rXK3bcS.gif)
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ A new command is added, `"move_by_paragraph"`.  Three `"args"` are accepted:
 - `"to_next"` (bool): True if the cursor should stay in this paragraph if possible.
     Default is true when moving forward, false when backward.
 
-There is also one setting:
+There is also one setting in `MoveByParagraph.sublime-settings`:
 
-- `"move_by_paragraph_ignores_whitespace"` (bool): Default false.
+- `"ignore_whitespace"` (bool): Default false.
     Set to true to treat lines containing only spaces and tabs as empty.
 
 

--- a/move_by_paragraph.py
+++ b/move_by_paragraph.py
@@ -52,8 +52,12 @@ class MyCommand(TextCommand):
 class MoveByParagraphCommand(MyCommand):
 
     def _is_empty(self, line):
-        # Okuno: I'm not sure why the second part of this clause is here
-        return not s # and self.view.substr(max(0, line.begin() - 1)) == '\n'
+        s = self.view.substr(line)
+        if self.view.settings().get('move_by_paragraph_ignores_whitespace', False):
+            return not s.strip()
+        else:
+            # Okuno: I'm not sure why the second part of this clause is here
+            return not s # and self.view.substr(max(0, line.begin() - 1)) == '\n'
 
     def _find_paragraph_position_forward(self, start, to_next):
         size = self.view.size()

--- a/move_by_paragraph.py
+++ b/move_by_paragraph.py
@@ -1,16 +1,19 @@
 from __future__ import print_function
+import sublime
 from sublime import Region
 from sublime_plugin import TextCommand
 from collections import Iterable
 
 
-DEBUG = False
 
+DEBUG = False
 
 def dbg(*msg):
     if DEBUG:
         print(' '.join(map(str, msg)))
 
+
+SETTINGS_FILE = "MoveByParagraph.sublime-settings"
 
 class MyCommand(TextCommand):
 
@@ -51,9 +54,13 @@ class MyCommand(TextCommand):
 
 class MoveByParagraphCommand(MyCommand):
 
+    def __init__(self, view):
+        super(MoveByParagraphCommand, self).__init__(view)
+        self.settings = sublime.load_settings(SETTINGS_FILE)
+
     def _is_empty(self, line):
         s = self.view.substr(line)
-        if self.view.settings().get('move_by_paragraph_ignores_whitespace', False):
+        if self.settings.get('ignore_whitespace', False):
             return not s.strip()
         else:
             # Okuno: I'm not sure why the second part of this clause is here


### PR DESCRIPTION
It struck me as unusual that selecting to the next paragraph selected blank lines following the current paragraph rather than stopping at the end of the current paragraph. Obviously, I can see the logic in the current behavior as well, so I added another argument `to_next` to control it.

While I was at it, this also addresses #4 with the setting `move_by_paragraph_ignores_whitespace`.
That's a pretty verbose name, but since this is my first plugin contribution, I'm not sure if there's a way to add a setting that doesn't pollute the global settings namespace.

I chose the defaults for both of these to be backwards-compatible. However, I did end up re-organizing the code to understand it better. To the best of my testing there shouldn't be any regressions, but there may be edge cases I missed.